### PR TITLE
Refactor configuration variable lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ By default the public and private keys are loaded via the `RECAPTCHA_PUBLIC_KEY`
 
 ```elixir
   config :recaptcha,
-    public_key: System.get_env("RECAPTCHA_PUBLIC_KEY"),
-    secret: System.get_env("RECAPTCHA_PRIVATE_KEY")
+    public_key: {:system, "RECAPTCHA_PUBLIC_KEY"},
+    secret: {:system, "RECAPTCHA_PRIVATE_KEY"}
 ```
 
 ## Usage

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,7 +3,7 @@ use Mix.Config
 config :recaptcha,
   verify_url: "https://www.google.com/recaptcha/api/siteverify",
   timeout: 5000,
-  public_key: System.get_env("RECAPTCHA_PUBLIC_KEY"),
-  secret: System.get_env("RECAPTCHA_PRIVATE_KEY")
+  public_key: {:system, "RECAPTCHA_PUBLIC_KEY"},
+  secret: {:system, "RECAPTCHA_PRIVATE_KEY"}
 
 import_config "#{Mix.env}.exs"

--- a/lib/recaptcha.ex
+++ b/lib/recaptcha.ex
@@ -5,6 +5,9 @@ defmodule Recaptcha do
     See the [documentation](https://developers.google.com/recaptcha/docs/verify)
     for more details.
   """
+
+  alias Recaptcha.Config
+
   @http_client Application.get_env(:recaptcha, :http_client, Recaptcha.Http)
 
   @doc """
@@ -48,7 +51,7 @@ defmodule Recaptcha do
 
   defp request_body(response, options) do
     body_options = Keyword.take(options, [:remote_ip, :secret])
-    application_options = [secret: Recaptcha.Config.get_env(:recaptcha, :secret)]
+    application_options = [secret: Config.get_env(:recaptcha, :secret)]
 
     # override application secret with options secret if it exists
     application_options

--- a/lib/recaptcha.ex
+++ b/lib/recaptcha.ex
@@ -48,7 +48,7 @@ defmodule Recaptcha do
 
   defp request_body(response, options) do
     body_options = Keyword.take(options, [:remote_ip, :secret])
-    application_options = [secret: Application.get_env(:recaptcha, :secret)]
+    application_options = [secret: Recaptcha.Config.get_env(:recaptcha, :secret)]
 
     # override application secret with options secret if it exists
     application_options

--- a/lib/recaptcha/config.ex
+++ b/lib/recaptcha/config.ex
@@ -1,0 +1,19 @@
+defmodule Recaptcha.Config do
+  @moduledoc """
+  Provides application/system environment variable lookup at runtime
+  """
+
+  @doc """
+  Returns the requested variable
+  """
+  @spec get_env(atom, atom, atom | map) :: term
+  def get_env(application, key, default \\ nil) do
+    application
+    |> Application.get_env(key, default)
+    |> _get_env()
+  end
+
+  defp _get_env({:system, env_variable}), do: System.get_env(env_variable)
+  defp _get_env(value), do: value
+
+end

--- a/lib/recaptcha/http.ex
+++ b/lib/recaptcha/http.ex
@@ -2,6 +2,9 @@ defmodule Recaptcha.Http do
   @moduledoc """
    Responsible for managing HTTP requests to the reCAPTCHA API
   """
+
+  alias Recaptcha.Config
+
   @headers [
     {"Content-type", "application/x-www-form-urlencoded"},
     {"Accept", "application/json"}
@@ -34,8 +37,8 @@ defmodule Recaptcha.Http do
   """
   @spec request_verification(map, [timeout: integer]) :: {:ok, map} | {:error, [atom]}
   def request_verification(body, options \\ []) do
-    timeout = options[:timeout] || Recaptcha.Config.get_env(:recaptcha, :timeout, 5000)
-    url = Recaptcha.Config.get_env(:recaptcha, :verify_url, @default_verify_url)
+    timeout = options[:timeout] || Config.get_env(:recaptcha, :timeout, 5000)
+    url = Config.get_env(:recaptcha, :verify_url, @default_verify_url)
 
     result =
       with {:ok, response} <- HTTPoison.post(url, body, @headers, timeout: timeout),

--- a/lib/recaptcha/http.ex
+++ b/lib/recaptcha/http.ex
@@ -34,8 +34,8 @@ defmodule Recaptcha.Http do
   """
   @spec request_verification(map, [timeout: integer]) :: {:ok, map} | {:error, [atom]}
   def request_verification(body, options \\ []) do
-    timeout = options[:timeout] || Application.get_env(:recaptcha, :timeout, 5000)
-    url = Application.get_env(:recaptcha, :verify_url, @default_verify_url)
+    timeout = options[:timeout] || Recaptcha.Config.get_env(:recaptcha, :timeout, 5000)
+    url = Recaptcha.Config.get_env(:recaptcha, :verify_url, @default_verify_url)
 
     result =
       with {:ok, response} <- HTTPoison.post(url, body, @headers, timeout: timeout),

--- a/lib/recaptcha/template.ex
+++ b/lib/recaptcha/template.ex
@@ -17,7 +17,7 @@ defmodule Recaptcha.Template do
   To convert the string to html code, use Phoenix.HTML.Raw/1 method
   """
   def display(options \\ []) do
-    public_key = options[:public_key] || Application.get_env(:recaptcha, :public_key)
+    public_key = options[:public_key] || Recaptcha.Config.get_env(:recaptcha, :public_key)
     render_template(public_key: public_key, options: options)
   end
 end

--- a/lib/recaptcha/template.ex
+++ b/lib/recaptcha/template.ex
@@ -8,6 +8,7 @@ defmodule Recaptcha.Template do
     In future this module may be separated out into a Phoenix specific library.
   """
   require Elixir.EEx
+  alias Recaptcha.Config
 
   EEx.function_from_file :defp, :render_template, "lib/template.html.eex", [:assigns]
 
@@ -17,7 +18,7 @@ defmodule Recaptcha.Template do
   To convert the string to html code, use Phoenix.HTML.Raw/1 method
   """
   def display(options \\ []) do
-    public_key = options[:public_key] || Recaptcha.Config.get_env(:recaptcha, :public_key)
+    public_key = options[:public_key] || Config.get_env(:recaptcha, :public_key)
     render_template(public_key: public_key, options: options)
   end
 end

--- a/test/recaptcha/config_test.exs
+++ b/test/recaptcha/config_test.exs
@@ -1,0 +1,16 @@
+defmodule RecaptchaConfigTest do
+  use ExUnit.Case, async: true
+
+  test "config can read regular config values" do
+    Application.put_env(:recaptcha, :test_var, "test")
+
+    assert Recaptcha.Config.get_env(:recaptcha, :test_var) == "test"
+  end
+
+  test "config can read environment variables" do
+    System.put_env("TEST_VAR", "test_env_vars")
+    Application.put_env(:recaptcha, :test_env_var, {:system, "TEST_VAR"})
+
+    assert Recaptcha.Config.get_env(:recaptcha, :test_env_var) == "test_env_vars"
+  end
+end


### PR DESCRIPTION
Change the `Application.get_env/3` calls to use a new function
`Recaptcha.Config.get_env/3` to perform the lookups. Doing so allows the
project to defer environment variable lookup to runtime instead of only at
compile-time.

For example, we can have the configuration be specified as each of the
following:

*   Standard variables:

    config :recaptcha,
        public_key: "some public key string",
        secret: "some private string"

*   Environment variable at compile time:

    config :recaptcha,
        public_key: System.get_env("RECAPTCHA_PUBLIC_KEY"),
        secret: System.get_env("RECAPTCHA_PRIVATE_KEY")

*   Environment variable at runtime:

    config :recaptcha,
        public_key: {:system, "RECPATCHA_PUBLIC_KEY"},
        secret: {:system, "RECAPTCHA_PRIVATE_KEY"}