### PR TITLE
Removed nil as an accepted value for response in the verify function

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -41,6 +41,8 @@
         {Credo.Check.Refactor.UnlessWithElse},
         {Credo.Check.Warning.IExPry},
         {Credo.Check.Warning.IoInspect},
+        {Credo.Check.Readability.Specs, false},
+        {Credo.Check.Readability.StringSigils, false},
         {Credo.Check.Warning.NameRedeclarationByAssignment},
         {Credo.Check.Warning.NameRedeclarationByCase},
         {Credo.Check.Warning.NameRedeclarationByDef},

--- a/lib/recaptcha.ex
+++ b/lib/recaptcha.ex
@@ -24,16 +24,8 @@ defmodule Recaptcha do
 
     {:ok, api_response} = Recaptcha.verify("response_string")
   """
-  @spec verify(String.t, [timeout: integer, secret: String.t,
-                          remote_ip: String.t]) :: {:ok, Recaptcha.Response.t} |
-                                                   {:error, [atom]}
-  def verify(response, options \\ [])
-
-  def verify(nil = _response, _) do
-    {:error, [:invalid_input_response]}
-  end
-
-  def verify(response, options) do
+  @spec verify(String.t, Keyword.t) :: {:ok, Recaptcha.Response.t} | {:error, [atom]}
+  def verify(response, options \\ []) do
     case @http_client.request_verification(
       request_body(response, options),
       Keyword.take(options, [:timeout])

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Recaptcha.Mixfile do
     [
       {:httpoison, "~> 0.9.0"},
       {:poison, "~> 1.5 or ~> 2.0"},
-      {:credo, "~> 0.4", only: [:dev, :test]},
+      {:credo, "~> 0.6", only: [:dev, :test]},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:excoveralls, "~> 0.5", only: :test},
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -14,5 +14,5 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], []},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
-%{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
+%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
-  "credo": {:hex, :credo, "0.4.11", "03a64e9d53309b7132556284dda0be57ba1013885725124cfea7748d740c6170", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
+  "credo": {:hex, :credo, "0.6.0", "44a82f82b94eeb4ba6092c89b8a6730ca1a3291c7940739d5acc8806d25ac991", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
   "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "excoveralls": {:hex, :excoveralls, "0.5.6", "35a903f6f78619ee7f951448dddfbef094b3a0d8581657afaf66465bc930468e", [:mix], [{:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},

--- a/test/recaptcha_test.exs
+++ b/test/recaptcha_test.exs
@@ -4,12 +4,7 @@ defmodule RecaptchaTest do
   # see https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha-v2-what-should-i-do
   @google_test_secret "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"
 
-  test "When the supplied g-recaptcha-response is nil, :invalid_input_response is returned" do
-    assert {:error, messages} = Recaptcha.verify(nil)
-    assert messages == [:invalid_input_response]
-  end
-
-  test "When the supplied g-recaptcha-response is not nil, but invalid, multiple errors are returned" do
+  test "When the supplied g-recaptcha-response is invalid, multiple errors are returned" do
     assert {:error, messages} = Recaptcha.verify("not_valid")
     assert messages == [:invalid_input_response, :invalid_input_secret]
   end


### PR DESCRIPTION
I don't think we should handle the case when `nil` is passed as a `response` into the `verify` function. I believe it should be checked outside the function, it's not our responsibility.

What do you think?