### PR TITLE
Correct REAME.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ By default the public and private keys are loaded via the `RECAPTCHA_PUBLIC_KEY`
 
 ```elixir
   config :recaptcha,
-    public_key: {:system, "RECAPTCHA_PUBLIC_KEY"},
-    secret: {:system, "RECAPTCHA_PRIVATE_KEY"}
+    public_key: System.get_env("RECAPTCHA_PUBLIC_KEY"),
+    secret: System.get_env("RECAPTCHA_PRIVATE_KEY")
 ```
 
 ## Usage


### PR DESCRIPTION
Correct `READMME.md` to reflect how to import environment variables in config files.