### PR TITLE
Add support for multiple languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Option                  | Action                                                
 :---------------------- | :----------------------------------------------------- | :------------------------
 `noscript`              | Renders default noscript code provided by google       | `false`
 `public_key`            | Sets key to the `data-sitekey` reCaptcha div attribute | Public key from the config file
+`hl`                    | Sets the language of the reCaptcha                     | en
 
 
 ### Verify API

--- a/lib/template.html.eex
+++ b/lib/template.html.eex
@@ -1,4 +1,4 @@
-<script src="https://www.google.com/recaptcha/api.js" async defer></script>
+<script src="https://www.google.com/recaptcha/api.js?hl=<%= @options[:hl] %>" async defer></script>
 
 <div class="g-recaptcha"
     data-sitekey="<%= @public_key %>"
@@ -15,7 +15,7 @@
     <div style="width: 302px; height: 422px;">
       <div style="width: 302px; height: 422px; position: relative;">
         <div style="width: 302px; height: 422px; position: absolute;">
-          <iframe src="https://www.google.com/recaptcha/api/fallback?k=<%= @public_key %>"
+          <iframe src="https://www.google.com/recaptcha/api/fallback?k=<%= @public_key %>&hl=<%= @options[:hl] %>"
                        frameborder="0" scrolling="no"
                        style="width: 302px; height:422px; border-style: none;">
           </iframe>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Recaptcha.Mixfile do
   def project do
     [
       app: :recaptcha,
-      version: "2.2.1",
+      version: "2.2.2",
       elixir: "~> 1.2",
       description: description(),
       deps: deps(),

--- a/test/recaptcha/template_test.exs
+++ b/test/recaptcha/template_test.exs
@@ -23,4 +23,10 @@ defmodule RecaptchaTemplateTest do
     assert template_string =~ "<noscript>"
     assert template_string =~ "https://www.google.com/recaptcha/api/fallback?k=test_public_key"
   end
+
+  test "supplying a hl in options to display/1 overrides it in the script tag" do
+    template_string = Recaptcha.Template.display(hl: "en")
+
+    assert template_string =~ "https://www.google.com/recaptcha/api.js?hl=en"
+  end
 end


### PR DESCRIPTION
This PR adds support for passing language to the recaptcha via the `hl` option.