### PR TITLE
Allow Recaptcha.verify call to pass options to http client

### DIFF
--- a/lib/recaptcha.ex
+++ b/lib/recaptcha.ex
@@ -28,7 +28,7 @@ defmodule Recaptcha do
   def verify(response, options \\ []) do
     verification = @http_client.request_verification(
       request_body(response, options),
-      Keyword.take(options, [:timeout])
+      options
     )
 
     case verification do

--- a/lib/recaptcha/http.ex
+++ b/lib/recaptcha/http.ex
@@ -35,13 +35,14 @@ defmodule Recaptcha.Http do
       remote_ip: "remote_ip"
     })
   """
-  @spec request_verification(binary, [timeout: integer]) :: {:ok, map} | {:error, [atom]}
+  @spec request_verification(binary, Keyword.t) :: {:ok, map} | {:error, [atom]}
   def request_verification(body, options \\ []) do
     timeout = options[:timeout] || Config.get_env(:recaptcha, :timeout, 5000)
     url = Config.get_env(:recaptcha, :verify_url, @default_verify_url)
 
+    opts = [{:timeout, timeout} | options]
     result =
-      with {:ok, response} <- HTTPoison.post(url, body, @headers, timeout: timeout),
+      with {:ok, response} <- HTTPoison.post(url, body, @headers, opts),
            {:ok, data} <- Poison.decode(response.body) do
         {:ok, data}
       end


### PR DESCRIPTION
Passes options through to http client so the caller can customize the client, e.g. `hackney` options