### PR TITLE
Invisible recaptcha working.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ By default the public and private keys are loaded via the `RECAPTCHA_PUBLIC_KEY`
 
 Use `raw` (if you're using Phoenix.HTML) and `Recaptcha.Template.display/1` methods to render the captcha widget.
 
+For recaptcha with checkbox
 ```html
 <form name="someform" method="post" action="/somewhere">
   ...
@@ -62,6 +63,16 @@ Use `raw` (if you're using Phoenix.HTML) and `Recaptcha.Template.display/1` meth
 </form>
 ```
 
+For invisible recaptcha
+```html
+<form name="someform" method="post" action="/somewhere">
+  ...
+  <%= raw Recaptcha.Template.display(size: "invisible") %>
+</form>
+  ...
+```
+To change the position of the invisible recaptcha, use an option badge. See https://developers.google.com/recaptcha/docs/invisible on the date-badge.
+
 `display` method accepts additional options as a keyword list, the options are:
 
 Option                  | Action                                                 | Default
@@ -69,7 +80,6 @@ Option                  | Action                                                
 `noscript`              | Renders default noscript code provided by google       | `false`
 `public_key`            | Sets key to the `data-sitekey` reCaptcha div attribute | Public key from the config file
 `hl`                    | Sets the language of the reCaptcha                     | en
-
 
 ### Verify API
 

--- a/lib/recaptcha/template.ex
+++ b/lib/recaptcha/template.ex
@@ -19,8 +19,15 @@ defmodule Recaptcha.Template do
   To convert the string to html code, use Phoenix.HTML.Raw/1 method
   """
   def display(options \\ []) do
-    public_key = options[:public_key] || Config.get_env(
-      :recaptcha, :public_key)
-    render_template(%{public_key: public_key, options: options})
+    public_key = options[:public_key] || Config.get_env(:recaptcha, :public_key)
+
+    callback =
+      if options[:size] == "invisible" && is_nil(options[:callback]) do
+        "recaptchaCallback"
+      else
+        options[:callback]
+      end
+
+    render_template(%{public_key: public_key, callback: callback, options: options})
   end
 end

--- a/lib/template.html.eex
+++ b/lib/template.html.eex
@@ -6,6 +6,7 @@
     data-type="<%= @options[:type] %>"
     data-tabindex="<%= @options[:tabindex] %>"
     data-size="<%= @options[:size] %>"
+    data-badge="<%= @options[:badge] %>"
     data-callback="<%= @options[:callback] %>">
 </div>
 

--- a/lib/template.html.eex
+++ b/lib/template.html.eex
@@ -1,4 +1,4 @@
-<script src="https://www.google.com/recaptcha/api.js?hl=<%= @options[:hl] %>" async defer></script>
+<script src="https://www.google.com/recaptcha/api.js?hl=<%= @options[:hl] %>" ></script>
 
 <div class="g-recaptcha"
     data-sitekey="<%= @public_key %>"
@@ -9,6 +9,14 @@
     data-badge="<%= @options[:badge] %>"
     data-callback="<%= @options[:callback] %>">
 </div>
+
+<%= if @options[:size] == "invisible" do %>
+<script type="text/javascript">
+  window.addEventListener('load', function() {
+    grecaptcha.execute()
+  })
+</script>
+<% end %>
 
 <%= if @options[:noscript] do %>
 

--- a/lib/template.html.eex
+++ b/lib/template.html.eex
@@ -1,5 +1,35 @@
 <script src="https://www.google.com/recaptcha/api.js?hl=<%= @options[:hl] %>" ></script>
 
+<%= if @options[:size] == "invisible" do %>
+<script type="text/javascript">
+  var form = null;
+
+  function onSubmit(event) {
+    event.preventDefault();
+
+    form = this;
+
+    var recaptchaObject = this.querySelector('div[class="g-recaptcha"]');
+
+    if (recaptchaObject) {
+      grecaptcha.execute();
+    } else {
+      this.submit();
+    }
+  }
+
+  function recaptchaCallback() {
+    form.submit();
+  }
+
+  var forms = document.querySelectorAll("form");
+
+  for (var i = 0; i < forms.length; i++) {
+    forms[i].addEventListener('submit', onSubmit);
+  };
+</script>
+<% end %>
+
 <div class="g-recaptcha"
     data-sitekey="<%= @public_key %>"
     data-theme="<%= @options[:theme] %>"
@@ -7,16 +37,8 @@
     data-tabindex="<%= @options[:tabindex] %>"
     data-size="<%= @options[:size] %>"
     data-badge="<%= @options[:badge] %>"
-    data-callback="<%= @options[:callback] %>">
+    data-callback="<%= @callback %>">
 </div>
-
-<%= if @options[:size] == "invisible" do %>
-<script type="text/javascript">
-  window.addEventListener('load', function() {
-    grecaptcha.execute()
-  })
-</script>
-<% end %>
 
 <%= if @options[:noscript] do %>
 

--- a/test/recaptcha/template_test.exs
+++ b/test/recaptcha/template_test.exs
@@ -12,16 +12,6 @@ defmodule RecaptchaTemplateTest do
     assert template_string =~ "data-badge=\"inline\""
   end
 
-  test "when invisible recaptcha, run the component at the window load" do
-    template_string = Recaptcha.Template.display(size: "invisible")
-
-    assert template_string =~ "grecaptcha.execute()"
-
-    template_string = Recaptcha.Template.display(size: "compact")
-
-    refute template_string =~ "grecaptcha.execute()"
-  end
-
   test "supplying a public key in options to display/1 overrides it in the g-recaptcha-div" do
     template_string = Recaptcha.Template.display(public_key: "override_test_public_key")
 
@@ -39,5 +29,13 @@ defmodule RecaptchaTemplateTest do
     template_string = Recaptcha.Template.display(hl: "en")
 
     assert template_string =~ "https://www.google.com/recaptcha/api.js?hl=en"
+  end
+
+  test "supplying a invisible recaptcha on option size equal invisible" do
+    template_string = Recaptcha.Template.display(size: "invisible")
+    assert template_string =~ "grecaptcha.execute()"
+
+    template_string = Recaptcha.Template.display(size: "compact")
+    refute template_string =~ "grecaptcha.execute()"
   end
 end

--- a/test/recaptcha/template_test.exs
+++ b/test/recaptcha/template_test.exs
@@ -12,6 +12,16 @@ defmodule RecaptchaTemplateTest do
     assert template_string =~ "data-badge=\"inline\""
   end
 
+  test "when invisible recaptcha, run the component at the window load" do
+    template_string = Recaptcha.Template.display(size: "invisible")
+
+    assert template_string =~ "grecaptcha.execute()"
+
+    template_string = Recaptcha.Template.display(size: "compact")
+
+    refute template_string =~ "grecaptcha.execute()"
+  end
+
   test "supplying a public key in options to display/1 overrides it in the g-recaptcha-div" do
     template_string = Recaptcha.Template.display(public_key: "override_test_public_key")
 

--- a/test/recaptcha/template_test.exs
+++ b/test/recaptcha/template_test.exs
@@ -2,13 +2,14 @@ defmodule RecaptchaTemplateTest do
   use ExUnit.Case, async: true
 
   test "supplying options to display/1 renders them in the g-recaptcha div" do
-    template_string = Recaptcha.Template.display(theme: "dark", type: "audio", tabindex: 1, size: "compact", callback: "enableBtn")
+    template_string = Recaptcha.Template.display(theme: "dark", type: "audio", tabindex: 1, size: "compact", callback: "enableBtn", badge: "inline")
 
     assert template_string =~ "data-theme=\"dark\""
     assert template_string =~ "data-type=\"audio\""
     assert template_string =~ "data-tabindex=\"1\""
     assert template_string =~ "data-size=\"compact\""
     assert template_string =~ "data-callback=\"enableBtn\""
+    assert template_string =~ "data-badge=\"inline\""
   end
 
   test "supplying a public key in options to display/1 overrides it in the g-recaptcha-div" do

--- a/test/recaptcha/template_test.exs
+++ b/test/recaptcha/template_test.exs
@@ -38,4 +38,15 @@ defmodule RecaptchaTemplateTest do
     template_string = Recaptcha.Template.display(size: "compact")
     refute template_string =~ "grecaptcha.execute()"
   end
+
+  test "supplying an option to change the callback even if you are using invisible recaptcha" do
+    template_string = Recaptcha.Template.display()
+    assert template_string =~ "data-callback=\"\""
+
+    template_string = Recaptcha.Template.display(size: "invisible")
+    assert template_string =~ "data-callback=\"recaptchaCallback\""
+
+    template_string = Recaptcha.Template.display(size: "invisible", callback: "myCallback")
+    assert template_string =~ "data-callback=\"myCallback\""
+  end
 end


### PR DESCRIPTION
I created the option to include a badge to be able to configure the Recaptcha position when using invisible recaptcha. I think it would be important to allow the user to pass any option, so we would not need to include in the code every Google update. If I consider it pertinent, I can do it here and open another PR.