### PR TITLE
Async loading of grecaptcha javascript file

### DIFF
--- a/lib/recaptcha/template.ex
+++ b/lib/recaptcha/template.ex
@@ -27,6 +27,9 @@ defmodule Recaptcha.Template do
         options[:callback]
       end
 
-    render_template(%{public_key: public_key, callback: callback, options: options})
+    onload = if options[:onload] do "onload=#{options[:onload]}&" else "" end
+    options_dict = Keyword.put(options, :onload, onload)
+
+    render_template(%{public_key: public_key, callback: callback, options: options_dict})
   end
 end

--- a/lib/template.html.eex
+++ b/lib/template.html.eex
@@ -4,14 +4,6 @@
 <script type="text/javascript">
   var form = null;
 
-  function onLoad() {
-    var submit_buttons = document.querySelectorAll('button[type="submit"]');
-
-    for (var i = 0; i < submit_buttons.length; i++) {
-      submit_buttons[i].disabled = false;
-    }
-  }
-
   function onSubmit(event) {
     event.preventDefault();
 

--- a/lib/template.html.eex
+++ b/lib/template.html.eex
@@ -1,8 +1,16 @@
-<script src="https://www.google.com/recaptcha/api.js?hl=<%= @options[:hl] %>" ></script>
+<script src="https://www.google.com/recaptcha/api.js?onload=onLoad&hl=<%= @options[:hl] %>" async defer></script>
 
 <%= if @options[:size] == "invisible" do %>
 <script type="text/javascript">
   var form = null;
+
+  function onLoad() {
+    var submit_buttons = document.querySelectorAll('button[type="submit"]');
+
+    for (var i = 0; i < submit_buttons.length; i++) {
+      submit_buttons[i].disabled = false;
+    }
+  }
 
   function onSubmit(event) {
     event.preventDefault();

--- a/lib/template.html.eex
+++ b/lib/template.html.eex
@@ -1,4 +1,4 @@
-<script src="https://www.google.com/recaptcha/api.js?onload=onLoad&hl=<%= @options[:hl] %>" async defer></script>
+<script src="https://www.google.com/recaptcha/api.js?<%= @options[:onload] %>hl=<%= @options[:hl] %>" async defer></script>
 
 <%= if @options[:size] == "invisible" do %>
 <script type="text/javascript">

--- a/test/recaptcha/template_test.exs
+++ b/test/recaptcha/template_test.exs
@@ -35,8 +35,14 @@ defmodule RecaptchaTemplateTest do
 
   test "supplying a hl in options to display/1 overrides it in the script tag" do
     template_string = Recaptcha.Template.display(hl: "en")
+    assert template_string =~ "https://www.google.com/recaptcha/api.js?hl=en"
+  end
 
-    assert template_string =~ "https://www.google.com/recaptcha/api.js?onload=onLoad&hl=en"
+  test "supplying a onload in options to display/1 adds it to the script tag" do
+    template_string1 = Recaptcha.Template.display(onload: "onLoad")
+    template_string2 = Recaptcha.Template.display(onload: "onLoad", hl: "en")
+    assert template_string1 =~ "https://www.google.com/recaptcha/api.js?onload=onLoad&hl"
+    assert template_string2 =~ "https://www.google.com/recaptcha/api.js?onload=onLoad&hl=en"
   end
 
   test "supplying a invisible recaptcha on option size equal invisible" do

--- a/test/recaptcha/template_test.exs
+++ b/test/recaptcha/template_test.exs
@@ -36,7 +36,7 @@ defmodule RecaptchaTemplateTest do
   test "supplying a hl in options to display/1 overrides it in the script tag" do
     template_string = Recaptcha.Template.display(hl: "en")
 
-    assert template_string =~ "https://www.google.com/recaptcha/api.js?hl=en"
+    assert template_string =~ "https://www.google.com/recaptcha/api.js?onload=onLoad&hl=en"
   end
 
   test "supplying a invisible recaptcha on option size equal invisible" do


### PR DESCRIPTION
Fixes #42.

Uses the `onload` callback to enable the submit button on the page once the script has finished loading.
Can be combined with for example `<%= submit "Submit", disabled: "disabled" %>` to first disable the button.