### PR TITLE
use extra_applications key

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ if you have any problems with migrating.
 
 ```elixir
   def application do
-    [ applications: [:recaptcha] ]
+    [ extra_applications: [:recaptcha] ]
   end
 ```
 


### PR DESCRIPTION
Hi,
Seems like in phoenix 1.4 applications are added under the key `extra_applications`.
In my fresh phoenix install, it has to look like this:
  ```
  def application do
    [
      mod: {Sot.Application, []},
      extra_applications: [:logger, :runtime_tools, :recaptcha]
    ]
  end