### PR TITLE
allow tests for failed captchas

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,30 @@ Option                  | Action                                                
 `secret`                | Private key to send as a parameter of the API request  | Private key from the config file
 `remote_ip`             | Optional. The user's IP address, used by reCaptcha     | no default
 
+
+## Testing
+
+In order to test your endpoints you should set the secret key to the following value in order to receive a positive result from all queries to the Recaptcha engine.
+
+```
+config :recaptcha,
+  secret: "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"
+```
+
+Setting up tests without network access can be done also. When configured as such a positive or negative result can be generated locally.
+
+```
+config :recaptcha,
+  http_client: Recaptcha.Http.MockClient,
+  secret: "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"
+
+
+  {:ok, _details} = Recaptcha.verify("valid_response")
+
+  {:error, _details} = Recaptcha.verify("invalid_response")
+
+```
+
 ## Contributing
 
 Check out [CONTRIBUTING.md](/CONTRIBUTING.md) if you want to help.

--- a/lib/recaptcha/http/mock_http_client.ex
+++ b/lib/recaptcha/http/mock_http_client.ex
@@ -21,6 +21,13 @@ defmodule Recaptcha.Http.MockClient do
      }}
   end
 
+  def request_verification(
+    "response=invalid_response&secret=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe" = body,
+    options) do
+    send(self(), {:request_verification, body, options})
+    {:error, [:"invalid-input-response"]}
+  end
+
   # every other match is a pass through to the real client
   def request_verification(body, options) do
     send(self(), {:request_verification, body, options})

--- a/lib/recaptcha/http/mock_http_client.ex
+++ b/lib/recaptcha/http/mock_http_client.ex
@@ -22,8 +22,10 @@ defmodule Recaptcha.Http.MockClient do
   end
 
   def request_verification(
-    "response=invalid_response&secret=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe" = body,
-    options) do
+        "response=invalid_response&secret=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe" =
+          body,
+        options
+      ) do
     send(self(), {:request_verification, body, options})
     {:error, [:"invalid-input-response"]}
   end

--- a/test/recaptcha_test.exs
+++ b/test/recaptcha_test.exs
@@ -14,6 +14,11 @@ defmodule RecaptchaTest do
              Recaptcha.verify("valid_response", secret: @google_test_secret)
   end
 
+  test "When a valid response is supplied, an error response is returned" do
+    assert {:error, [:"invalid-input-response"]} =
+             Recaptcha.verify("invalid_response", secret: @google_test_secret)
+  end
+
   test "When secret is not overridden the configured secret is used" do
     Recaptcha.verify("valid_response")
 


### PR DESCRIPTION
Sometimes in my controller tests I like to check the behavior when the recapcha fails. These modifications came in handy for that. Maybe they will seem useful to you too.