### PR TITLE
Update jason to 1.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule Recaptcha.Mixfile do
   defp deps do
     [
       {:httpoison, ">= 0.12.0"},
-      {:jason, "~> 1.1.0", optional: true},
+      {:jason, "~> 1.2", optional: true},
       {:credo, "~> 1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:dialyxir, "~> 0.5", only: [:dev]},


### PR DESCRIPTION
Hello!

I received this message when doing a routine update of my dependencies:

```
Resolving Hex dependencies...

Failed to use "jason" (version 1.2.2) because
  bamboo (version 2.2.0) requires ~> 1.0
  phoenix (version 1.6.0) requires ~> 1.0
  recaptcha (version 3.1.0) requires ~> 1.1.0
  mix.lock specifies 1.2.2
```

Would you find this PR helpful?