### PR TITLE
Add recaptcha v3 support

### DIFF
--- a/lib/recaptcha.ex
+++ b/lib/recaptcha.ex
@@ -1,6 +1,6 @@
 defmodule Recaptcha do
   @moduledoc """
-  A module for verifying reCAPTCHA version 2.0 response strings.
+  A module for verifying reCAPTCHA response strings.
 
   See the [documentation](https://developers.google.com/recaptcha/docs/verify)
   for more details.
@@ -40,6 +40,22 @@ defmodule Recaptcha do
 
       {:ok, %{"success" => false, "error-codes" => errors}} ->
         {:error, Enum.map(errors, &atomise_api_error/1)}
+
+      {:ok,
+       %{
+         "success" => true,
+         "challenge_ts" => timestamp,
+         "hostname" => host,
+         "action" => action,
+         "score" => score
+       }} ->
+        {:ok,
+         %Response{
+           challenge_ts: timestamp,
+           hostname: host,
+           action: action,
+           score: score
+         }}
 
       {:ok,
        %{"success" => true, "challenge_ts" => timestamp, "hostname" => host}} ->

--- a/lib/recaptcha/http.ex
+++ b/lib/recaptcha/http.ex
@@ -13,7 +13,7 @@ defmodule Recaptcha.Http do
   @default_verify_url "https://www.google.com/recaptcha/api/siteverify"
 
   @doc """
-  Sends an HTTP request to the reCAPTCHA version 2.0 API.
+  Sends an HTTP request to the reCAPTCHA API.
 
   See the [docs](https://developers.google.com/recaptcha/docs/verify#api-response)
   for more details on the API response.
@@ -28,6 +28,8 @@ defmodule Recaptcha.Http do
         "success" => success,
         "challenge_ts" => ts,
         "hostname" => host,
+        "score" => score,
+        "action" => action,
         "error-codes" => errors
       }} = Recaptcha.Http.request_verification(%{
         secret: "secret",
@@ -55,6 +57,7 @@ defmodule Recaptcha.Http do
       {:error, :invalid} -> {:error, [:invalid_api_response]}
       {:error, {:invalid, _reason}} -> {:error, [:invalid_api_response]}
       {:error, %{reason: reason}} -> {:error, [reason]}
+      {:error, %{"error-codes" => error_codes}} -> {:error, error_codes}
     end
   end
 end

--- a/lib/recaptcha/http/mock_http_client.ex
+++ b/lib/recaptcha/http/mock_http_client.ex
@@ -17,7 +17,9 @@ defmodule Recaptcha.Http.MockClient do
      %{
        "success" => true,
        "challenge_ts" => "timestamp",
-       "hostname" => "localhost"
+       "hostname" => "localhost",
+       "score" => 1.0,
+       "action" => "mock"
      }}
   end
 

--- a/lib/recaptcha/response.ex
+++ b/lib/recaptcha/response.ex
@@ -2,7 +2,7 @@ defmodule Recaptcha.Response do
   @moduledoc """
   A struct representing the successful recaptcha response from the reCAPTCHA API.
   """
-  defstruct challenge_ts: "", hostname: ""
+  defstruct challenge_ts: "", hostname: "", action: "", score: 0.0
 
-  @type t :: %__MODULE__{challenge_ts: String.t(), hostname: String.t()}
+  @type t :: %__MODULE__{challenge_ts: String.t(), hostname: String.t(), action: String.t(), score: Float.t()}
 end


### PR DESCRIPTION
This PR adds basic support for Recaptcha v3 as requested in #67 while maintaining compatibility with v2

It simply adds the `action` and `score` fields to the response model.